### PR TITLE
Run `rubocop` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,13 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - run: bundle exec rspec
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+      - run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,9 +33,6 @@ Security:
 Style/BlockComments:
   Enabled: true
 
-Style/BracesAroundHashParameters:
-  Enabled: true
-
 Style/CaseEquality:
   Enabled: true
 
@@ -181,10 +178,10 @@ Style/TrailingMethodEndStatement:
 Style/TrivialAccessors:
   Enabled: true
 
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Enabled: true
 
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Enabled: true
 
 Style/UnpackFirst:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -192,3 +192,6 @@ Style/YodaCondition:
 
 Style/ZeroLengthPredicate:
   Enabled: true
+
+Layout/BlockAlignment:
+  Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
       pry (>= 0.13, < 0.16)
     racc (1.8.1)
     rainbow (3.1.1)
+    rexml (3.4.1)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -41,13 +42,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.5)
-    rubocop (0.75.0)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.6)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.13.0)
     unicode-display_width (1.6.1)
 
@@ -58,7 +60,7 @@ DEPENDENCIES
   bundler
   pry-byebug
   rspec (~> 3.8)
-  rubocop (= 0.75.0)
+  rubocop (~> 0.81.0)
   safety_net_attestation!
 
 BUNDLED WITH

--- a/android_safety_net.gemspec
+++ b/android_safety_net.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rspec", "~> 3.8"
-  spec.add_development_dependency "rubocop", "0.75.0"
+  spec.add_development_dependency "rubocop", "~> 0.81.0"
 end

--- a/lib/safety_net_attestation/fixed_length_secure_compare.rb
+++ b/lib/safety_net_attestation/fixed_length_secure_compare.rb
@@ -6,7 +6,7 @@ module SafetyNetAttestation
   module FixedLengthSecureCompare
     unless OpenSSL.singleton_class.method_defined?(:fixed_length_secure_compare)
       refine OpenSSL.singleton_class do
-        def fixed_length_secure_compare(a, b) # rubocop:disable Naming/UncommunicativeMethodParamName
+        def fixed_length_secure_compare(a, b) # rubocop:disable Naming/MethodParameterName
           raise ArgumentError, "inputs must be of equal length" unless a.bytesize == b.bytesize
 
           # borrowed from Rack::Utils

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ def generate_key
   OpenSSL::PKey::RSA.new(2048)
 end
 
-# rubocop:disable Naming/UncommunicativeMethodParamName
+# rubocop:disable Naming/MethodParameterName
 def generate_cert(dn, key, serial, issuer, not_before: nil, not_after: nil)
   cert = OpenSSL::X509::Certificate.new
   issuer = cert unless issuer
@@ -51,4 +51,4 @@ def issue_cert(dn, key, serial, extensions, issuer: nil, issuer_key: nil, not_be
   cert.sign(issuer_key, "sha256")
   cert
 end
-# rubocop:enable Naming/UncommunicativeMethodParamName
+# rubocop:enable Naming/MethodParameterName


### PR DESCRIPTION
#### Summary

- Change `rubocop` constraint to `~> 0.81.0`
- Update `rubocop` cops
- Run `rubocop` on the CI