### PR TITLE
Update `rubocop` from `0.81.0` to `1.80.2`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,7 @@ Layout:
 Lint:
   Enabled: true
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Naming:

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in safety_net_attestation.gemspec
 gemspec
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0")
+  gem "rubocop", "~> 1.80", require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,14 +12,17 @@ GEM
     byebug (12.0.0)
     coderay (1.1.3)
     diff-lcs (1.6.2)
-    jaro_winkler (1.5.6)
+    json (2.13.2)
     jwt (2.10.2)
       base64
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     method_source (1.1.0)
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
+    prism (1.5.1)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -28,7 +31,7 @@ GEM
       pry (>= 0.13, < 0.16)
     racc (1.8.1)
     rainbow (3.1.1)
-    rexml (3.4.1)
+    regexp_parser (2.11.3)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -42,16 +45,24 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.5)
-    rubocop (0.81.0)
-      jaro_winkler (~> 1.5.1)
+    rubocop (1.80.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      rexml
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.46.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.46.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
     ruby-progressbar (1.13.0)
-    unicode-display_width (1.6.1)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.1.0)
 
 PLATFORMS
   ruby
@@ -60,7 +71,7 @@ DEPENDENCIES
   bundler
   pry-byebug
   rspec (~> 3.8)
-  rubocop (~> 0.81)
+  rubocop (~> 1.80)
   safety_net_attestation!
 
 BUNDLED WITH

--- a/android_safety_net.gemspec
+++ b/android_safety_net.gemspec
@@ -32,5 +32,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rspec", "~> 3.8"
-  spec.add_development_dependency "rubocop", "~> 0.81"
 end


### PR DESCRIPTION
#### What?

This PR updates **RuboCop** to version `1.80.2` while ensuring compatibility with legacy **Ruby** versions (2.3 and 2.4). It also updates the **RuboCop** configuration to replace a deprecated cop reference, aligning with newer **RuboCop** standards.
